### PR TITLE
build: add release.yml to enable autogenerated release notes

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,30 @@
+---
+changelog:
+  exclude:
+    labels: []
+    authors: []
+  categories:
+    - title: User-facing features
+      labels:
+        - feat
+    - title: Bug fixes
+      labels:
+        - fix
+    - title: Performance improvements
+      labels:
+        - perf
+    - title: Documentation updates
+      labels:
+        - docs
+    - title: Formatting changes
+      labels:
+        - style
+    - title: Refactoring
+      labels:
+        - refactor
+    - title: Test updates
+      labels:
+        - test
+    - title: Build system updates
+      labels:
+        - build


### PR DESCRIPTION
Adds a release.yml [to enable auto-generated release notes](https://docs.github.com/en/repositories/releasing-projects-on-github/automatically-generated-release-notes).