### PR TITLE
pyatls: version 0.0.2

### DIFF
--- a/python-package/pyproject.toml
+++ b/python-package/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pyatls"
-version = "0.0.1"
+version = "0.0.2"
 description = "A Python package that implements Attested TLS (aTLS)."
 readme = "README.md"
 authors = [{ name = "Opaque Systems", email = "pypi@opaque.co" }]


### PR DESCRIPTION
Bump version to 0.0.2, which includes connection pooling support.