### PR TITLE
pyatls: improve packaging, version 0.0.4

### DIFF
--- a/python-package/README.md
+++ b/python-package/README.md
@@ -7,7 +7,7 @@ tokens via the Azure Attestation Service (AAS) running on Azure Container
 Instance (ACI) instances.
 
 For the moment, this package exists to support
-[`promptguard`](https://pypi.org/project/promptguard/), a confidential
+[`OpaquePrompts`](https://pypi.org/project/opaqueprompts/), a confidential
 information redaction service that runs in a Trusted Execution Environment
 (TEE).
 

--- a/python-package/pyproject.toml
+++ b/python-package/pyproject.toml
@@ -27,6 +27,9 @@ dependencies = [
     "urllib3 >= 2.0.0, < 2.1.0",
 ]
 
+[project.optional-dependencies]
+requests = ["requests"]
+
 [project.urls]
 Homepage = "https://github.com/opaque-systems/atls-python"
 

--- a/python-package/pyproject.toml
+++ b/python-package/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pyatls"
-version = "0.0.3"
+version = "0.0.4"
 description = "A Python package that implements Attested TLS (aTLS)."
 readme = "README.md"
 authors = [{ name = "Opaque Systems", email = "pypi@opaque.co" }]

--- a/python-package/pyproject.toml
+++ b/python-package/pyproject.toml
@@ -11,14 +11,14 @@ classifiers = [
     "License :: OSI Approved :: Apache Software License",
 ]
 keywords = [
-    "confidential",
-    "llm",
-    "tls",
-    "ssl",
     "atls",
     "attestation",
-    "security",
+    "confidential",
+    "llm",
     "privacy",
+    "security",
+    "ssl",
+    "tls",
 ]
 dependencies = [
     "cryptography",


### PR DESCRIPTION
# Overview

This PR includes a few minor changes to the library's packaging. More specifically, it minimally tidies up `pyproject.toml`, adds the `requests` package as an optional dependency, updates the `README` to point to OpaquePrompts on PyPI after it's been renamed, and bumps this package's version to `0.0.4` for publishing to PyPI.

## Optional Dependencies

The `requests` package is not strictly necessary for this package's operation, so it is not listed as a dependency. At the same time, if one installs `pyatls` and attempts to import its support for the `requests` package, one will be met with a missing dependency. Conversely, if a consumer of `pyatls` does not need `requests`, we also do not install it needlessly by default.

With this change, one can do:

```sh
pip install pyatls[requests]
```

if one needs `requests` support, and simply:

```sh
pip install pyatls
```

otherwise.

For reference, see the [setuptools documentation for optional dependencies](https://setuptools.pypa.io/en/latest/userguide/dependency_management.html#optional-dependencies).